### PR TITLE
Add reverse-proxy multi-user auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,27 @@ Mintplex Labs & the community maintain a number of deployment methods, scripts, 
 
 [or set up a production AnythingLLM instance without Docker →](./BARE_METAL.md)
 
+### Reverse-Proxy Auth + Multi-User
+
+Traefik → Authelia → Anything-LLM
+
+```yaml
+services:
+  traefik:
+    image: traefik:v2.11
+    # configuration...
+  authelia:
+    image: authelia/authelia
+    # configuration...
+  anything-llm:
+    image: ghcr.io/mintplex-labs/anything-llm:latest
+    environment:
+      - REVERSE_PROXY_AUTH_ENABLED=true
+      - REVERSE_PROXY_AUTH_ADMIN_GROUPS=admins
+      - REVERSE_PROXY_AUTH_MANAGER_GROUPS=managers
+```
+
+
 ## How to setup for development
 
 - `yarn setup` To fill in the required `.env` files you'll need in each of the application sections (from root of repo).

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ services:
       - REVERSE_PROXY_AUTH_ENABLED=true
       - REVERSE_PROXY_AUTH_ADMIN_GROUPS=admins
       - REVERSE_PROXY_AUTH_MANAGER_GROUPS=managers
+      - REVERSE_PROXY_AUTH_DEFAULT_ROLE=default
 ```
 
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -333,6 +333,8 @@ GID='1000'
 
 # Comma separated groups that map to the manager role when using reverse-proxy auth
 # REVERSE_PROXY_AUTH_MANAGER_GROUPS=managers
+# Role to assign when a user is not in admin or manager groups
+# REVERSE_PROXY_AUTH_DEFAULT_ROLE=default
 
 # Allow scraping of any IP address in collector - must be string "true" to be enabled
 # See https://docs.anythingllm.com/configuration#local-ip-address-scraping for more information.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -331,6 +331,9 @@ GID='1000'
 # SIMPLE_SSO_ENABLED=1
 # SIMPLE_SSO_NO_LOGIN=1
 
+# Comma separated groups that map to the manager role when using reverse-proxy auth
+# REVERSE_PROXY_AUTH_MANAGER_GROUPS=managers
+
 # Allow scraping of any IP address in collector - must be string "true" to be enabled
 # See https://docs.anythingllm.com/configuration#local-ip-address-scraping for more information.
 # COLLECTOR_ALLOW_ANY_IP="true"

--- a/server/.env.example
+++ b/server/.env.example
@@ -330,6 +330,8 @@ TTS_PROVIDER="native"
 
 # Comma separated groups that map to the manager role when using reverse-proxy auth
 # REVERSE_PROXY_AUTH_MANAGER_GROUPS=managers
+# Role to assign when a user is not in admin or manager groups
+# REVERSE_PROXY_AUTH_DEFAULT_ROLE=default
 
 # Allow scraping of any IP address in collector - must be string "true" to be enabled
 # See https://docs.anythingllm.com/configuration#local-ip-address-scraping for more information.

--- a/server/.env.example
+++ b/server/.env.example
@@ -328,6 +328,9 @@ TTS_PROVIDER="native"
 # SIMPLE_SSO_ENABLED=1
 # SIMPLE_SSO_NO_LOGIN=1
 
+# Comma separated groups that map to the manager role when using reverse-proxy auth
+# REVERSE_PROXY_AUTH_MANAGER_GROUPS=managers
+
 # Allow scraping of any IP address in collector - must be string "true" to be enabled
 # See https://docs.anythingllm.com/configuration#local-ip-address-scraping for more information.
 # COLLECTOR_ALLOW_ANY_IP="true"

--- a/server/__tests__/auth.proxy.test.js
+++ b/server/__tests__/auth.proxy.test.js
@@ -30,6 +30,7 @@ describe("userFromSession reverse proxy", () => {
     process.env.REVERSE_PROXY_AUTH_ENABLED = "true";
     process.env.REVERSE_PROXY_AUTH_ADMIN_GROUPS = "admins";
     process.env.REVERSE_PROXY_AUTH_MANAGER_GROUPS = "managers";
+    process.env.REVERSE_PROXY_AUTH_DEFAULT_ROLE = "default";
   });
 
   test("assigns admin role from group", async () => {

--- a/server/__tests__/auth.proxy.test.js
+++ b/server/__tests__/auth.proxy.test.js
@@ -1,0 +1,72 @@
+jest.mock("../models/user", () => {
+  const store = [];
+  return {
+    User: {
+      findOrCreate: jest.fn(async ({ username }) => {
+        let user = store.find((u) => u.username === username);
+        const created = !user;
+        if (!user) {
+          user = { id: store.length + 1, username, role: "default" };
+          store.push(user);
+        }
+        return { user, created };
+      }),
+      _update: jest.fn(async (id, data) => {
+        const user = store.find((u) => u.id === id);
+        Object.assign(user, data);
+        return { user, message: null };
+      }),
+      count: jest.fn(async (clause) => store.filter((u) => u.username === clause.username).length),
+    },
+  };
+});
+
+const { userFromSession } = require("../utils/http");
+const { User } = require("../models/user");
+
+describe("userFromSession reverse proxy", () => {
+  beforeEach(() => {
+    process.env.MULTI_USER_MODE = "true";
+    process.env.REVERSE_PROXY_AUTH_ENABLED = "true";
+    process.env.REVERSE_PROXY_AUTH_ADMIN_GROUPS = "admins";
+    process.env.REVERSE_PROXY_AUTH_MANAGER_GROUPS = "managers";
+  });
+
+  test("assigns admin role from group", async () => {
+    const req = {
+      header: (h) => ({
+        "Remote-User": "alice",
+        "Remote-Groups": "admins",
+      }[h]),
+    };
+    const user = await userFromSession(req);
+    expect(user.username).toBe("alice");
+    expect(user.role).toBe("admin");
+    expect(await User.count({ username: "alice" })).toBe(1);
+    const user2 = await userFromSession(req);
+    expect(user2.id).toBe(user.id);
+    expect(await User.count({ username: "alice" })).toBe(1);
+  });
+
+  test("assigns manager role from group", async () => {
+    const req = {
+      header: (h) => ({
+        "Remote-User": "bob",
+        "Remote-Groups": "team,managers",
+      }[h]),
+    };
+    const user = await userFromSession(req);
+    expect(user.role).toBe("manager");
+  });
+
+  test("defaults to normal role", async () => {
+    const req = {
+      header: (h) => ({
+        "Remote-User": "eve",
+        "Remote-Groups": "users",
+      }[h]),
+    };
+    const user = await userFromSession(req);
+    expect(user.role).toBe("default");
+  });
+});

--- a/server/utils/http/index.js
+++ b/server/utils/http/index.js
@@ -29,6 +29,37 @@ async function userFromSession(request, response = null) {
     return response.locals.user;
   }
 
+  const proxyEnabled =
+    process.env.MULTI_USER_MODE === "true" &&
+    process.env.REVERSE_PROXY_AUTH_ENABLED === "true";
+  const remoteUser = request.header("Remote-User");
+  if (proxyEnabled && remoteUser) {
+    const remoteGroups = (request.header("Remote-Groups") || "")
+      .split(",")
+      .map((g) => g.trim())
+      .filter(Boolean);
+
+    const { user, created } = await User.findOrCreate({ username: remoteUser });
+    const adminGroups = (process.env.REVERSE_PROXY_AUTH_ADMIN_GROUPS || "")
+      .split(",")
+      .map((g) => g.trim())
+      .filter(Boolean);
+    const managerGroups = (process.env.REVERSE_PROXY_AUTH_MANAGER_GROUPS || "")
+      .split(",")
+      .map((g) => g.trim())
+      .filter(Boolean);
+
+    let role = "default";
+    if (remoteGroups.some((g) => adminGroups.includes(g))) role = "admin";
+    else if (remoteGroups.some((g) => managerGroups.includes(g))) role = "manager";
+
+    if (user && user.role !== role) {
+      await User._update(user.id, { role });
+      user.role = role;
+    }
+    return user;
+  }
+
   const auth = request.header("Authorization");
   const token = auth ? auth.split(" ")[1] : null;
 

--- a/server/utils/http/index.js
+++ b/server/utils/http/index.js
@@ -49,7 +49,13 @@ async function userFromSession(request, response = null) {
       .map((g) => g.trim())
       .filter(Boolean);
 
-    let role = "default";
+    const validRoles = ["admin", "manager", "default"];
+    const defaultRoleEnv = process.env.REVERSE_PROXY_AUTH_DEFAULT_ROLE;
+    const defaultRole = validRoles.includes(defaultRoleEnv)
+      ? defaultRoleEnv
+      : "default";
+
+    let role = defaultRole;
     if (remoteGroups.some((g) => adminGroups.includes(g))) role = "admin";
     else if (remoteGroups.some((g) => managerGroups.includes(g))) role = "manager";
 


### PR DESCRIPTION
## Summary
- support reverse-proxy auth in `userFromSession`
- allow creating missing users and mapping groups to roles
- add helper `User.findOrCreate`
- document reverse-proxy auth setup
- expose `REVERSE_PROXY_AUTH_MANAGER_GROUPS` env variable
- test reverse-proxy auth scenarios

## Testing
- `npm test` *(fails: missing field `enableTracing` when running prisma binaries)*

------
https://chatgpt.com/codex/tasks/task_e_686aca895060832a8ce37ae2917925fa