### PR TITLE
Ensure reverse proxy users initialized

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -7,7 +7,7 @@ const express = require("express");
 const bodyParser = require("body-parser");
 const cors = require("cors");
 const path = require("path");
-const { reqBody } = require("./utils/http");
+const { reqBody, userFromSession } = require("./utils/http");
 const { systemEndpoints } = require("./endpoints/system");
 const { workspaceEndpoints } = require("./endpoints/workspaces");
 const { chatEndpoints } = require("./endpoints/chat");
@@ -73,6 +73,17 @@ embeddedEndpoints(apiRouter);
 browserExtensionEndpoints(apiRouter);
 
 if (process.env.NODE_ENV !== "development") {
+  if ("REVERSE_PROXY_AUTH" in process.env) {
+    app.use(async (request, response, next) => {
+      try {
+        await userFromSession(request, response);
+      } catch (e) {
+        console.error(e.message);
+      } finally {
+        next();
+      }
+    });
+  }
   const { MetaGenerator } = require("./utils/boot/MetaGenerator");
   const IndexPage = new MetaGenerator();
 


### PR DESCRIPTION
## Summary
- import `userFromSession` into `server/index.js`
- run this helper before serving the SPA when `REVERSE_PROXY_AUTH` is set

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686c1d868258832a9ff0ac42f8dc1b35