### PR TITLE
Add reverse proxy auth support

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -330,6 +330,8 @@ GID='1000'
 # See https://docs.anythingllm.com/configuration#simple-sso-passthrough for more information.
 # SIMPLE_SSO_ENABLED=1
 # SIMPLE_SSO_NO_LOGIN=1
+# Enable authentication via reverse proxy headers Remote-User and Remote-Groups.
+# REVERSE_PROXY_AUTH_ENABLED=true
 
 # Allow scraping of any IP address in collector - must be string "true" to be enabled
 # See https://docs.anythingllm.com/configuration#local-ip-address-scraping for more information.

--- a/server/.env.example
+++ b/server/.env.example
@@ -327,6 +327,8 @@ TTS_PROVIDER="native"
 # See https://docs.anythingllm.com/configuration#simple-sso-passthrough for more information.
 # SIMPLE_SSO_ENABLED=1
 # SIMPLE_SSO_NO_LOGIN=1
+# Enable authentication via reverse proxy headers Remote-User and Remote-Groups.
+# REVERSE_PROXY_AUTH_ENABLED=true
 
 # Allow scraping of any IP address in collector - must be string "true" to be enabled
 # See https://docs.anythingllm.com/configuration#local-ip-address-scraping for more information.

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -1085,6 +1085,7 @@ function dumpENV() {
     // Simple SSO
     "SIMPLE_SSO_ENABLED",
     "SIMPLE_SSO_NO_LOGIN",
+    "REVERSE_PROXY_AUTH_ENABLED",
     // Community Hub
     "COMMUNITY_HUB_BUNDLE_DOWNLOADS_ENABLED",
 

--- a/server/utils/http/index.js
+++ b/server/utils/http/index.js
@@ -29,6 +29,14 @@ async function userFromSession(request, response = null) {
     return response.locals.user;
   }
 
+  if (process.env.REVERSE_PROXY_AUTH_ENABLED === "true") {
+    const proxyUser = request.header("Remote-User");
+    if (proxyUser) {
+      const user = await User.get({ username: proxyUser });
+      if (user) return user;
+    }
+  }
+
   const auth = request.header("Authorization");
   const token = auth ? auth.split(" ")[1] : null;
 


### PR DESCRIPTION
## Summary
- support reverse proxy auth in middleware
- fetch users from `Remote-User` header when enabled
- document `REVERSE_PROXY_AUTH_ENABLED` in env examples
- persist new env var via `updateENV`

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686c1d790738832a9a518ccff6dfd912